### PR TITLE
Fix asset manifest issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-babel": "^5.1.7",
-    "ember-data": "^2.10.0",
+    "ember-data": "^2.10.0"
+  },
+  "peerDependencies": {
     "ember-engines": "0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-engines must be provided by the host application for engines. Including it in the individual engine is problematic since we expect certain setup for engines to only occur once in the root of the application.